### PR TITLE
[encoder] Allow setting the initial value manually

### DIFF
--- a/encoder/encoder.py
+++ b/encoder/encoder.py
@@ -47,7 +47,7 @@ ACCEL_THRESHOLD = const(5)
 
 class Encoder(object):
     def __init__(self, pin_clk, pin_dt, pin_mode=None, clicks=1,
-                 min_val=0, max_val=100, accel=0, reverse=False):
+                 min_val=0, max_val=100, accel=0, reverse=False, init_val=0):
         self.pin_clk = (pin_clk if isinstance(pin_clk, Pin) else
                         Pin(pin_clk, Pin.IN, pin_mode))
         self.pin_dt = (pin_dt if isinstance(pin_dt, Pin) else
@@ -62,7 +62,7 @@ class Encoder(object):
 
         # The following variables are assigned to in the interrupt callback,
         # so we have to allocate them here.
-        self._value = 0
+        self._value = init_val
         self._readings = 0
         self._state = 0
         self.cur_accel = 0


### PR DESCRIPTION
Sometimes it's desirable to set the initial value to a predefined value (say, a encoder that controls both "volume" and "frequency", by switching between these functions, it's helpful if we can set the initial value to the current internal value.

I've been doing this by setting the min_val to -100, and then applying the offset to my current value, but I've figured this is more elegant.
I've tried to keep it compatible with how it was previously, but please correct me if this is not right.